### PR TITLE
Tiny sanity-check problem

### DIFF
--- a/wrapper/sw_wrapper.c
+++ b/wrapper/sw_wrapper.c
@@ -91,7 +91,7 @@ int sw_read_netcdf(const char *ifile) {
   if ((nstr < 0) || (nstr > 4)) error_and_exit("sw_nstr must be 0 -- 3.");
   if ((ireflect < 0) || (ireflect > 1)) 
     error_and_exit("sw_ireflect must be 0 or 1.");
-  if ((solvar < 0) || (solvar > 1)) 
+  if ((solvar < 0) || (solvar > 3)) 
     error_and_exit("sw_solvar must be between 0 and 3.");
   if ((semis < 0) || (semis > 1)) 
     error_and_exit("semis must be between 0 and 1.");


### PR DESCRIPTION
Hi Tom,

We've been using this pyrrtm code here in Exeter for a while now, and it's excellent! Thanks for making it work so nicely! 

One of the students has tried playing around with the solar constant via `solvar`, and a problem came up that when she made solvar>1 the code would call `error_and_exit`. This small change stops it doing that for solvar<3. 

Thanks,
Stephen